### PR TITLE
Fix #5. Use type fragment specifier instead of path to allow sequence types to be accepted.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,42 +128,42 @@ mod unary;
 /// See the [module level documentation](index.html) for more information.
 #[macro_export]
 macro_rules! impl_op {
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => {
+    ($op:tt |$lhs_i:ident : &mut $lhs:ty, $rhs_i:ident : &$rhs:ty| $body:block) => {
         $crate::_parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {
             |$lhs_i: &mut $lhs, $rhs_i: &$rhs| -> () { $body }(lhs, rhs);
         });
     };
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => {
+    ($op:tt |$lhs_i:ident : &mut $lhs:ty, $rhs_i:ident : $rhs:ty| $body:block) => {
         $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {
             |$lhs_i: &mut $lhs, $rhs_i: $rhs| -> () { $body }(lhs, rhs);
         });
     };
-    ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : &$lhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_unary_op!($op, &$lhs, $out, lhs, {
             |$lhs_i: &$lhs| -> $out { $body }(lhs)
         });
     };
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_binary_op!($op, &$lhs, &$rhs, $out, lhs, rhs, {
             |$lhs_i: &$lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
         });
     };
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {
             |$lhs_i: &$lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
         });
     };
-    ($op:tt |$lhs_i:ident : $lhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : $lhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_unary_op!($op, $lhs, $out, lhs, {
             |$lhs_i: $lhs| -> $out { $body }(lhs)
         });
     };
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {
             |$lhs_i: $lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
         });
     };
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => {
         $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {
             |$lhs_i: $lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
         });
@@ -220,35 +220,35 @@ macro_rules! impl_op {
 /// }
 #[macro_export]
 macro_rules! impl_op_ex {
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => (
+    ($op:tt |$lhs_i:ident : &mut $lhs:ty, $rhs_i:ident : &$rhs:ty| $body:block) => (
         $crate::_parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, rhs);});
         $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, &rhs);});
     );
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => (
+    ($op:tt |$lhs_i:ident : &mut $lhs:ty, $rhs_i:ident : $rhs:ty| $body:block) => (
         $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : $rhs| -> () {$body} (lhs, rhs);});
     );
-    ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty| -> $out:ty $body:block) => (
         $crate::_parse_unary_op!($op, &$lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (lhs)});
         $crate::_parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (&lhs)});
     );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
         $crate::_parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
         $crate::_parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, rhs)});
         $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, &rhs)});
     );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
         $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&lhs, rhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path|  -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty|  -> $out:ty $body:block) => (
         $crate::_parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : $lhs| -> $out {$body} (lhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
         $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
     );
 }
@@ -304,19 +304,19 @@ macro_rules! impl_op_ex {
 /// }
 #[macro_export]
 macro_rules! impl_op_commutative {
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
         $crate::_parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
     );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
         $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
         $crate::_parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
         $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
     );
@@ -402,7 +402,7 @@ macro_rules! impl_op_commutative {
 /// }
 #[macro_export]
 macro_rules! impl_op_ex_commutative {
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
 
         $crate::_parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
@@ -410,19 +410,19 @@ macro_rules! impl_op_ex_commutative {
         $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
         $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&rhs, &lhs)});
     );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : &$lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
 
         $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
         $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&rhs, lhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : &$rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op_ex!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
 
         $crate::_parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
         $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
     );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
+    ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => (
         $crate::impl_op_commutative!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
     );
 }

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -221,3 +221,31 @@ mod multiline {
         assert_eq!(kong::Donkey::new(0), dk);
     }
 }
+
+mod impl_op_sequence_types {
+    use super::*;
+
+    impl_op!(+= |a: &mut kong::Donkey, b: (i32, i32)| { a.bananas += b.0; });
+    #[test]
+    fn tuple() {
+        let mut dk = kong::Donkey::new(3);
+        dk += (1, 2);
+        assert_eq!(kong::Donkey::new(3 + 1), dk);
+    }
+
+    impl_op!(+= |a: &mut kong::Donkey, b: [i32; 2]| { a.bananas += b[0]; });
+    #[test]
+    fn array() {
+        let mut dk = kong::Donkey::new(3);
+        dk += [1, 2];
+        assert_eq!(kong::Donkey::new(3 + 1), dk);
+    }
+
+    impl_op!(+= |a: &mut kong::Donkey, b: &[i32]| { a.bananas += b[0]; });
+    #[test]
+    fn slice() {
+        let mut dk = kong::Donkey::new(3);
+        dk += vec![1, 2].as_slice();
+        assert_eq!(kong::Donkey::new(3 + 1), dk);
+    }
+}

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -628,3 +628,28 @@ fn infer_lifetimes() {
         do_bitor_2(&kong::Dixie::new(1), &kong::Donkey::new(2))
     );
 }
+
+mod impl_op_sequence_types {
+    use super::*;
+
+    impl_op!(+ |a: kong::Donkey, b: (i32, i32)| -> kong::Donkey { kong::Donkey::new(a.bananas + b.0) });
+    #[test]
+    fn tuple() {
+        assert_eq!(kong::Donkey::new(1 + 2), kong::Donkey::new(1) + (2, 3));
+    }
+
+    impl_op!(+ |a: kong::Donkey, b: [i32; 2]| -> kong::Donkey { kong::Donkey::new(a.bananas + b[0]) });
+    #[test]
+    fn array() {
+        assert_eq!(kong::Donkey::new(1 + 2), kong::Donkey::new(1) + [2, 3]);
+    }
+
+    impl_op!(+ |a: kong::Donkey, b: &[i32]| -> kong::Donkey { kong::Donkey::new(a.bananas + b[0]) });
+    #[test]
+    fn slice() {
+        assert_eq!(
+            kong::Donkey::new(1 + 2),
+            kong::Donkey::new(1) + vec![2, 3].as_slice()
+        );
+    }
+}


### PR DESCRIPTION
Change the :path specifiers to :ty in order to accept sequence types. This should be seamless as [TypePath](https://doc.rust-lang.org/reference/paths.html#paths-in-types) is a subset of [Type](https://doc.rust-lang.org/reference/types.html#type-expressions) and the internal macros in e.g. binary.rs already expect a Type for 'lhs', 'rhs', and 'out' anyway.