### PR TITLE
Switch from `std::ops` to `core::ops`.

### DIFF
--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -17,7 +17,7 @@ macro_rules! _parse_assignment_op {
 #[macro_export]
 macro_rules! _impl_assignment_op_internal {
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<&$rhs> for $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<&$rhs> for $lhs {
             $(#[$attrs])*
             fn $ops_fn(&mut self, $rhs_i: &$rhs) {
                 #[allow(unused_mut)]
@@ -26,7 +26,7 @@ macro_rules! _impl_assignment_op_internal {
             }
         }
 
-        impl$($generic_params)* ::std::ops::$ops_trait<&$rhs> for &mut $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<&$rhs> for &mut $lhs {
             fn $ops_fn(&mut self, $rhs_i: &$rhs) {
                 #[allow(unused_mut)]
                 let mut $lhs_i = self;
@@ -35,7 +35,7 @@ macro_rules! _impl_assignment_op_internal {
         }
     };
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<$rhs> for $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<$rhs> for $lhs {
             $(#[$attrs])*
             fn $ops_fn(&mut self, $rhs_i: $rhs) {
                 #[allow(unused_mut)]
@@ -44,7 +44,7 @@ macro_rules! _impl_assignment_op_internal {
             }
         }
 
-        impl$($generic_params)* ::std::ops::$ops_trait<$rhs> for &mut $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<$rhs> for &mut $lhs {
             fn $ops_fn(&mut self, $rhs_i: $rhs) {
                 #[allow(unused_mut)]
                 let mut $lhs_i = self;

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -40,7 +40,7 @@ macro_rules! _impl_binary_op_internal {
 #[macro_export]
 macro_rules! _impl_binary_op_owned_owned {
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<$rhs> for $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<$rhs> for $lhs {
             type Output = $out;
 
             $(#[$attrs])*
@@ -56,7 +56,7 @@ macro_rules! _impl_binary_op_owned_owned {
 #[macro_export]
 macro_rules! _impl_binary_op_owned_borrowed {
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<&$rhs> for $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<&$rhs> for $lhs {
             type Output = $out;
 
             $(#[$attrs])*
@@ -72,7 +72,7 @@ macro_rules! _impl_binary_op_owned_borrowed {
 #[macro_export]
 macro_rules! _impl_binary_op_borrowed_owned {
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<$rhs> for &$lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<$rhs> for &$lhs {
             type Output = $out;
 
             $(#[$attrs])*
@@ -88,7 +88,7 @@ macro_rules! _impl_binary_op_borrowed_owned {
 #[macro_export]
 macro_rules! _impl_binary_op_borrowed_borrowed {
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait<&$rhs> for &$lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait<&$rhs> for &$lhs {
             type Output = $out;
 
             $(#[$attrs])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //!     }
 //! }
 //!
-//! impl_op!(+ <T: ::std::ops::Add<T>> |a: Barrel<T>, b: Barrel<T>| -> Barrel<<T as ::std::ops::Add<T>>::Output> {
+//! impl_op!(+ <T: ::core::ops::Add<T>> |a: Barrel<T>, b: Barrel<T>| -> Barrel<<T as ::core::ops::Add<T>>::Output> {
 //!     Barrel::new(a.bananas + b.bananas)
 //! });
 //!

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -9,7 +9,7 @@ macro_rules! _parse_unary_op {
 #[macro_export]
 macro_rules! _impl_unary_op_internal {
     ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $out:ty, $lhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait for &$lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait for &$lhs {
             type Output = $out;
 
             $(#[$attrs])*
@@ -20,7 +20,7 @@ macro_rules! _impl_unary_op_internal {
         }
     };
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $out:ty, $lhs_i:ident, $(#[$attrs:meta])* $body:block $($generic_params:tt)*) => {
-        impl$($generic_params)* ::std::ops::$ops_trait for $lhs {
+        impl$($generic_params)* ::core::ops::$ops_trait for $lhs {
             type Output = $out;
 
             $(#[$attrs])*

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -238,7 +238,7 @@ mod generic_params {
     impl Marker for u8 {}
     impl Marker for i8 {}
 
-    impl_op!(+= <T: ::std::ops::AddAssign<T> + Marker>|a: &mut kong::Barrel<T>, b: kong::Barrel<T>| { a.bananas += b.bananas; });
+    impl_op!(+= <T: ::core::ops::AddAssign<T> + Marker>|a: &mut kong::Barrel<T>, b: kong::Barrel<T>| { a.bananas += b.bananas; });
     #[test]
     fn impl_op() {
         let mut barrel = kong::Barrel::new(3u8);
@@ -250,7 +250,7 @@ mod generic_params {
         assert_eq!(kong::Barrel::new(-5i8), barrel);
     }
 
-    impl_op_ex!(-= <T: ::std::ops::SubAssign<T> + Marker + Copy>|a: &mut kong::Barrel<T>, b: &kong::Barrel<T>| { a.bananas -= b.bananas; });
+    impl_op_ex!(-= <T: ::core::ops::SubAssign<T> + Marker + Copy>|a: &mut kong::Barrel<T>, b: &kong::Barrel<T>| { a.bananas -= b.bananas; });
     #[test]
     fn impl_op_ex() {
         let mut barrel = kong::Barrel::new(10u8);

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -532,8 +532,8 @@ mod generic_params {
 
     impl_op!(
         +
-        <T: ::std::ops::Add<T> + Marker>
-        |a: kong::Barrel<T>, b: kong::Barrel<T>| -> kong::Barrel<<T as ::std::ops::Add<T>>::Output> {
+        <T: ::core::ops::Add<T> + Marker>
+        |a: kong::Barrel<T>, b: kong::Barrel<T>| -> kong::Barrel<<T as ::core::ops::Add<T>>::Output> {
             kong::Barrel::new(a.bananas + b.bananas)
         }
     );
@@ -551,8 +551,8 @@ mod generic_params {
 
     impl_op_commutative!(
         *
-        <T: ::std::ops::Mul<T> + Marker>
-        |a: kong::Barrel<i32>, b: kong::Barrel<T>| -> kong::Barrel<<T as ::std::ops::Mul<T>>::Output> {
+        <T: ::core::ops::Mul<T> + Marker>
+        |a: kong::Barrel<i32>, b: kong::Barrel<T>| -> kong::Barrel<<T as ::core::ops::Mul<T>>::Output> {
             kong::Barrel::new(T::from_i32(a.bananas) * b.bananas)
         }
     );
@@ -578,8 +578,8 @@ mod generic_params {
 
     impl_op_ex!(
         -
-        <T: ::std::ops::Sub<T> + Marker + Copy>
-        |a: &kong::Barrel<T>, b: &kong::Barrel<T>| -> kong::Barrel<<T as ::std::ops::Sub<T>>::Output> {
+        <T: ::core::ops::Sub<T> + Marker + Copy>
+        |a: &kong::Barrel<T>, b: &kong::Barrel<T>| -> kong::Barrel<<T as ::core::ops::Sub<T>>::Output> {
             kong::Barrel::new(a.bananas - b.bananas)
         }
     );
@@ -621,8 +621,8 @@ mod generic_params {
 
     impl_op_ex_commutative!(
         &
-        <T: ::std::ops::BitAnd<T> + Marker + Copy>
-        |a: &kong::Barrel<i32>, b: &kong::Barrel<T>| -> kong::Barrel<<T as ::std::ops::BitAnd<T>>::Output> {
+        <T: ::core::ops::BitAnd<T> + Marker + Copy>
+        |a: &kong::Barrel<i32>, b: &kong::Barrel<T>| -> kong::Barrel<<T as ::core::ops::BitAnd<T>>::Output> {
             kong::Barrel::new(T::from_i32(a.bananas) & b.bananas)
         }
     );

--- a/tests/syntax.rs
+++ b/tests/syntax.rs
@@ -55,7 +55,7 @@ fn parens() {
 
 #[test]
 fn generic_params() {
-    impl_op!(/<A: Copy + 'static, B: ::std::ops::Add<A>>|a: Bar<A, B>, b: Bar<A, B>| -> B::Output {
+    impl_op!(/<A: Copy + 'static, B: ::core::ops::Add<A>>|a: Bar<A, B>, b: Bar<A, B>| -> B::Output {
         b.1 + a.0
     });
 


### PR DESCRIPTION
Even though the crate is `no_std`, the macros are using `std`. This fixes them to use `core`, which should work for both `std` and `no_std`.